### PR TITLE
Cleaned up huge memory leak

### DIFF
--- a/src/Image.cc
+++ b/src/Image.cc
@@ -2,6 +2,7 @@
 #include <node.h>
 #include <node_buffer.h>
 
+#include <stdlib.h>
 #include <string.h>
 
 #include "Epeg.h"
@@ -129,7 +130,7 @@ Image::Process(const FunctionCallbackInfo<Value> &args)
 
   Local<Value> buffer = node::Buffer::New(isolate, size).ToLocalChecked();
   memcpy(node::Buffer::Data(buffer), data, size);
-
+  free(data); 
   args.GetReturnValue().Set(buffer);
 }
 


### PR DESCRIPTION
After running the module on a large number of images, the memory usage was very very high. Looking at the source, I found that the image "data" has to be freed once handed off to node because the epeg library's image class does not free it

Works really well now!